### PR TITLE
run using lein classpath and lein-koan "0.1.2"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject core.logic-koans "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/core.logic "0.6.5"]]
-  :dev-dependencies [[lein-koan "0.1.1"]])
+                 [org.clojure/core.logic "0.6.5"]
+                 [lein-koan "0.1.2"]])

--- a/script/run
+++ b/script/run
@@ -1,13 +1,4 @@
 #!/bin/sh
-CLASSPATH=src
-
-for f in lib/*.jar lib/dev/*.jar resources/; do
-  CLASSPATH=$CLASSPATH:$f
-done
-
-if [ "$OSTYPE" = "cygwin" ]; then
-	CLASSPATH=`cygpath -wp $CLASSPATH`
-fi
-
+CLASSPATH=`lein classpath`
 java -cp "$CLASSPATH" clojure.main script/run.clj
 echo


### PR DESCRIPTION
Changes the script/run to use the classpath provided by `lein classpath`
and updates the lein-koan dependency in project.clj to "0.1.2".

This is what it took for me to run the koans following the instructions in README.md
